### PR TITLE
style: UIFont를 확장하여 커스텀 폰트 추가

### DIFF
--- a/iOS_Wegg/iOS_Wegg.xcodeproj/project.pbxproj
+++ b/iOS_Wegg/iOS_Wegg.xcodeproj/project.pbxproj
@@ -64,6 +64,13 @@
 			);
 			target = 0E98E9D42D2D009D006F25EF /* iOS_Wegg */;
 		};
+		0E98ED352D3E6CDE006F25EF /* Exceptions for "Utilities" folder in "iOS_Wegg" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Extensions/UIFont+extensions.swift",
+			);
+			target = 0E98E9D42D2D009D006F25EF /* iOS_Wegg */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -101,6 +108,9 @@
 		};
 		0E98EA3F2D2F979A006F25EF /* Utilities */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				0E98ED352D3E6CDE006F25EF /* Exceptions for "Utilities" folder in "iOS_Wegg" target */,
+			);
 			path = Utilities;
 			sourceTree = "<group>";
 		};

--- a/iOS_Wegg/iOS_Wegg/Core/Utilities/Extensions/UIFont+extensions.swift
+++ b/iOS_Wegg/iOS_Wegg/Core/Utilities/Extensions/UIFont+extensions.swift
@@ -1,0 +1,30 @@
+//
+//  UIFont+extensions.swift
+//  iOS_Wegg
+//
+//  Created by jaewon Lee on 1/20/25.
+//
+
+import Foundation
+import UIKit
+
+extension UIFont {
+    enum GmarketSansStyle: String {
+        case bold = "GmarketSansTTFBold"
+        case medium = "GmarketSansTTFMedium"
+        case light = "GmarketSansTTFLight"
+    }
+
+    enum NotoSansStyle: String {
+        case medium = "NotoSansKR-Medium"
+        case regular = "NotoSansKR-Regular"
+    }
+
+    static func gmarketSans(_ type: GmarketSansStyle, size: CGFloat) -> UIFont? {
+        return UIFont(name: type.rawValue, size: size)
+    }
+
+    static func notoSans(_ type: NotoSansStyle, size: CGFloat) -> UIFont? {
+        return UIFont(name: type.rawValue, size: size)
+    }
+}


### PR DESCRIPTION
## 📋 작업 요약
- UIFont에 커스텀 폰트 확장
## ✒️ 변경 사항
- Extenstion 아래에 파일 생성
## 📈 테스트 결과
- [x] 코드가 정상적으로 동작함.
- [x] 모든 기능이 구현됨.
- [x] SwiftLint 검사 통과.
- [x] 새로운 의존성 추가 시 README 업데이트.
- [x] iPhone 16 Pro와 iPhone 13mini에서 테스트 완료

## 🙏 리뷰 요청 사항
### 테스트 코드
```swift
UIColor.gmarketSans(.bold, size: 20)
```
### GmarketSans Bold 사용 결과
![image](https://github.com/user-attachments/assets/8567b87b-5da6-4a0d-9315-079769886cee)



