### PR TITLE
style: UIColor에 커스텀 색상 확장

### DIFF
--- a/iOS_Wegg/iOS_Wegg.xcodeproj/project.pbxproj
+++ b/iOS_Wegg/iOS_Wegg.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		0E98ED352D3E6CDE006F25EF /* Exceptions for "Utilities" folder in "iOS_Wegg" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				"Extensions/UIColor+extensions.swift",
 				"Extensions/UIFont+extensions.swift",
 			);
 			target = 0E98E9D42D2D009D006F25EF /* iOS_Wegg */;

--- a/iOS_Wegg/iOS_Wegg/Core/Utilities/Extensions/UIColor+extensions.swift
+++ b/iOS_Wegg/iOS_Wegg/Core/Utilities/Extensions/UIColor+extensions.swift
@@ -1,0 +1,41 @@
+//
+//  UIColor+extensions.swift
+//  iOS_Wegg
+//
+//  Created by jaewon Lee on 1/20/25.
+//
+
+import Foundation
+import UIKit
+
+extension UIColor {
+    /// 앱의 주요 색상 그룹 정의
+    enum CustomColor {
+        case primary
+        case secondary
+        //        case background
+        //        case accent
+        
+        /// 색상 반환
+        func color() -> UIColor {
+            switch self {
+            case .primary:
+                guard let color = UIColor(named: "BluePrimary") else {
+                    return UIColor(red: 0.0, green: 0.6, blue: 1.0, alpha: 1.0) // 기본 파랑
+                }
+                return color
+            case .secondary:
+                guard let color = UIColor(named: "YellowSecondary") else {
+                    return UIColor(red: 1.0, green: 0.8, blue: 0.0, alpha: 1.0) // 기본 노랑
+                }
+                return color
+            }
+        }
+    }
+    
+    /// Static 메서드로 사용 가능
+    /// - UIFont.customColor(.primary)
+    static func customColor(_ color: CustomColor) -> UIColor {
+        return color.color()
+    }
+}


### PR DESCRIPTION
## 📋 작업 요약
- primary 색상과 secondary 색상 UIColor에 확장
## ✒️ 변경 사항
- Extension 폴더 아래 파일 생성
## 📈 테스트 결과
- [x] 코드가 정상적으로 동작함.
- [x] 모든 기능이 구현됨.
- [x] SwiftLint 검사 통과.
- [x] 새로운 의존성 추가 시 README 업데이트.
- [x] iPhone 16 Pro와 iPhone 13mini에서 테스트 완료
### 테스트 코드 및 스크린샷
```swift
UIColor.customColor(.primary)
```
![image](https://github.com/user-attachments/assets/b36fcca4-f0cb-463b-a4ef-2ee823548610)

## 🙏 리뷰 요청 사항
- x
