### PR TITLE
feat: 캘린더 화면 팔로우 수, 팔로잉 수, 프로필 이미지, 닉네임(accountId) API 연동

### DIFF
--- a/iOS_Wegg/iOS_Wegg.xcodeproj/project.pbxproj
+++ b/iOS_Wegg/iOS_Wegg.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		0E98EB8A2D3A274B006F25EF /* GmarketSansTTFLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0E98EB862D3A274B006F25EF /* GmarketSansTTFLight.ttf */; };
 		0E98EC942D3BD206006F25EF /* NotoSansKR-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0E98EC922D3BD206006F25EF /* NotoSansKR-Medium.ttf */; };
 		0E98EC952D3BD206006F25EF /* NotoSansKR-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0E98EC932D3BD206006F25EF /* NotoSansKR-Regular.ttf */; };
+		7B45A21C2D6440CB001AD28B /* FollowResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B45A21B2D6440CB001AD28B /* FollowResponse.swift */; };
 		7B75AA692D625D1200882385 /* TodoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B75AA682D625D1200882385 /* TodoRequest.swift */; };
 		7B75AA6B2D625D3E00882385 /* TodoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B75AA6A2D625D3E00882385 /* TodoResponse.swift */; };
 		DE0020B92D3F75E6003A273F /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = DE0020B82D3F75E6003A273F /* KakaoSDK */; };
@@ -71,6 +72,7 @@
 		0E98EB872D3A274B006F25EF /* GmarketSansTTFMedium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = GmarketSansTTFMedium.ttf; sourceTree = "<group>"; };
 		0E98EC922D3BD206006F25EF /* NotoSansKR-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-Medium.ttf"; sourceTree = "<group>"; };
 		0E98EC932D3BD206006F25EF /* NotoSansKR-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-Regular.ttf"; sourceTree = "<group>"; };
+		7B45A21B2D6440CB001AD28B /* FollowResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowResponse.swift; sourceTree = "<group>"; };
 		7B75AA682D625D1200882385 /* TodoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoRequest.swift; sourceTree = "<group>"; };
 		7B75AA6A2D625D3E00882385 /* TodoResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoResponse.swift; sourceTree = "<group>"; };
 		DE0020D42D41EC0E003A273F /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -406,6 +408,14 @@
 			path = NotoSans;
 			sourceTree = "<group>";
 		};
+		7B45A2182D6440B6001AD28B /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				7B45A21B2D6440CB001AD28B /* FollowResponse.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
 		7B75AA672D625D0A00882385 /* Todo */ = {
 			isa = PBXGroup;
 			children = (
@@ -491,6 +501,7 @@
 		FF7985672D5A86510055B370 /* NetworkModel */ = {
 			isa = PBXGroup;
 			children = (
+				7B45A2182D6440B6001AD28B /* Home */,
 				7B75AA672D625D0A00882385 /* Todo */,
 				DED22CFF2D5FA108003245C8 /* SignUp */,
 				DED22CEC2D5F7F7F003245C8 /* Post */,
@@ -679,6 +690,7 @@
 				DED22D042D5FC27C003245C8 /* SignUpRequest.swift in Sources */,
 				DED22D052D5FC27C003245C8 /* SignUpResponse.swift in Sources */,
 				DED22CED2D5F7FBA003245C8 /* UploadRequest.swift in Sources */,
+				7B45A21C2D6440CB001AD28B /* FollowResponse.swift in Sources */,
 				DED22CEE2D5F7FBA003245C8 /* UploadResponse.swift in Sources */,
 				DED22CEF2D5F7FBA003245C8 /* HotPlaceRequest.swift in Sources */,
 				DED22E672D61A142003245C8 /* VerificationRequest.swift in Sources */,

--- a/iOS_Wegg/iOS_Wegg/Core/Services/API/APIConstants.swift
+++ b/iOS_Wegg/iOS_Wegg/Core/Services/API/APIConstants.swift
@@ -53,4 +53,8 @@ struct APIConstants {
             return "/todo/\(todoId)"
         }
     }
+    
+    struct Follow {
+        static let followLabelURL = "/home/follow"
+    }
 }

--- a/iOS_Wegg/iOS_Wegg/Core/Services/API/Targets/Home/FollowAPI.swift
+++ b/iOS_Wegg/iOS_Wegg/Core/Services/API/Targets/Home/FollowAPI.swift
@@ -1,0 +1,38 @@
+//
+//  FollowAPI.swift
+//  iOS_Wegg
+//
+//  Created by KKM on 2/18/25.
+//
+
+import Foundation
+import Moya
+
+enum FollowAPI {
+    case getFollowInfo
+}
+
+extension FollowAPI: TargetType {
+    var baseURL: URL {
+        guard let url = URL(string: APIConstants.baseURL) else {
+            fatalError("❌ 잘못된 Base URL: \(APIConstants.baseURL)")
+        }
+        return url
+    }
+    
+    var path: String {
+        return APIConstants.Follow.followLabelURL
+    }
+    
+    var method: Moya.Method {
+        return .get
+    }
+    
+    var task: Task {
+        return .requestPlain
+    }
+    
+    var headers: [String : String]? {
+        return ["Content-Type": "application/json"]
+    }
+}

--- a/iOS_Wegg/iOS_Wegg/Screen/Home/Calendar/View/CalendarView.swift
+++ b/iOS_Wegg/iOS_Wegg/Screen/Home/Calendar/View/CalendarView.swift
@@ -16,13 +16,13 @@ class CalendarView: UIView {
         $0.contentMode = .scaleAspectFit
     }
     
-    private let profileLabel = UILabel().then {
+    let profileLabel = UILabel().then {
         $0.text = "Me"
         $0.font = .notoSans(.medium, size: 14)
         $0.textColor = .secondary
     }
     
-    private let followerLabel = UILabel().then {
+    let followerLabel = UILabel().then {
         $0.text = "0\n팔로워"
         $0.font = .notoSans(.medium, size: 20)
         $0.textColor = .secondary
@@ -30,7 +30,7 @@ class CalendarView: UIView {
         $0.textAlignment = .center
     }
     
-    private let followingLabel = UILabel().then {
+    let followingLabel = UILabel().then {
         $0.text = "0\n팔로잉"
         $0.font = .notoSans(.medium, size: 20)
         $0.textColor = .secondary

--- a/iOS_Wegg/iOS_Wegg/Screen/Home/Calendar/ViewController/CalendarViewController.swift
+++ b/iOS_Wegg/iOS_Wegg/Screen/Home/Calendar/ViewController/CalendarViewController.swift
@@ -6,6 +6,7 @@
 import UIKit
 
 class CalendarViewController: UIViewController {
+    private let apiManager = APIManager()
     
     let calendarView = CalendarView()
     private var days: [String] = []
@@ -30,6 +31,8 @@ class CalendarViewController: UIViewController {
         // 초기 상태 설정
         calendarView.calendarCollectionView.isHidden = false
         calendarView.studyTimeView.isHidden = true
+        
+        fetchFollowInfo()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -43,6 +46,30 @@ class CalendarViewController: UIViewController {
         
         calendarView.studyTimeView.studyTimeCollectionView.dataSource = self
         calendarView.studyTimeView.studyTimeCollectionView.delegate = self
+    }
+    
+    private func fetchFollowInfo() {
+        Task {
+            do {
+                let followResponse: FollowResponse = try await apiManager.request(
+                    target: FollowAPI.getFollowInfo)
+                await updateUI(with: followResponse.result)
+            } catch {
+                print("Error fetching follow info: \(error)")
+                // 에러 처리 로직 추가
+            }
+        }
+    }
+    
+    private func updateUI(with result: FollowResult) {
+        calendarView.followerLabel.text = "\(result.followerCount)\n팔로워"
+        calendarView.followingLabel.text = "\(result.followingCount)\n팔로잉"
+        calendarView.profileLabel.text = result.accountId
+        if let imageURLString = result.profileImage, let imageURL = URL(string: imageURLString) {
+            // 프로필 이미지 로드 및 설정 (URLSession 또는 이미지 로딩 라이브러리 사용)
+            // 예: SDWebImage 라이브러리 사용
+            // calendarView.profileIcon.sd_setImage(with: imageURL, completed: nil)
+        }
     }
     
     private func setupButtonActions() {

--- a/iOS_Wegg/iOS_Wegg/Screen/Home/HomeMain/ViewController/HomeViewController.swift
+++ b/iOS_Wegg/iOS_Wegg/Screen/Home/HomeMain/ViewController/HomeViewController.swift
@@ -27,7 +27,7 @@ class HomeViewController: UIViewController, UIScrollViewDelegate, ToDoListViewDe
         homeView.headerView.viewController = self
         homeView.headerView.updateHeaderMode(isHomeMode: true)
         
-        apiManager.setCookie(value: "9B054ED826CCEE55F59353174E0A4755")
+        apiManager.setCookie(value: "4DCFDEB49A1AE96A8C23F0BDE537A0F8")
         print("[HomeVC] JSESSIONID 쿠키 설정 완료")
         
         // 투두 리스트 및 달성률 불러오기

--- a/iOS_Wegg/iOS_Wegg/Screen/Models/NetworkModel/Home/FollowResponse.swift
+++ b/iOS_Wegg/iOS_Wegg/Screen/Models/NetworkModel/Home/FollowResponse.swift
@@ -1,0 +1,22 @@
+//
+//  FollowResponse.swift
+//  iOS_Wegg
+//
+//  Created by KKM on 2/18/25.
+//
+
+import Foundation
+
+struct FollowResponse: Decodable {
+    let isSuccess: Bool
+    let code: String
+    let message: String
+    let result: FollowResult
+}
+
+struct FollowResult: Decodable {
+    let followerCount: Int
+    let followingCount: Int
+    let profileImage: String?
+    let accountId: String
+}


### PR DESCRIPTION
## 🧑‍🚀 PR 요약
#### 작업 내용
해당 pr에서 작업한 내역을 적어주세요.

- GET 방식으로 팔로잉, 팔로우, 프로필 이미지, 닉네임 API를 받아옴
- FollowAPI 작성
- FollowResponse 작성
- APIConstants에 "/home/follow" URL 추가

#### 📌 변경 사항
변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요.

- CalendarView와 CalendarViewController에 임시로 저장하던 데이터 삭제 후 API로 대체

#### 📸 ScreenShot
- [X] iPhone 16 Pro와 iPhone 13mini에서 테스트 완료
- 스크린샷은 하나의 기기에서 진행한 내용만 첨부(ex. iPhone 16Pro)
<img width="612" alt="스크린샷 2025-02-18 오후 1 34 07" src="https://github.com/user-attachments/assets/51f046d2-28e9-4a35-a614-3c4a45b5bb69" />

#### 🙏 리뷰 요청 사항
- FollowAPI
- Screen/Home/Calendar/View/CalendarView
- Screen/Home/Calendar/ViewController/CalendarViewController
- 위 코드들을 중심으로 봐주세요!

#### 🔗 Linked Issue
close #133 

#### ✅ PR check list
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```